### PR TITLE
Add follow_redirects middleware

### DIFF
--- a/app/helpers/fair_score_helper.rb
+++ b/app/helpers/fair_score_helper.rb
@@ -21,6 +21,7 @@ module FairScoreHelper
         time = Benchmark.realtime do
           conn = Faraday.new do |conn|
             conn.options.timeout = 30
+            conn.response :follow_redirects
           end
           response = conn.get(get_fairness_service_url(apikey) + "&ontologies=#{ontologies_acronyms}&combined")
           if response.status.eql?(200)


### PR DESCRIPTION
Adding the `:follow_redirects` middleware to follows  automatically  HTTP redirects (301, 302, etc.)