### PR TITLE
feature: hide automatic mappings

### DIFF
--- a/app/components/switch_input_component.rb
+++ b/app/components/switch_input_component.rb
@@ -3,7 +3,7 @@
 class SwitchInputComponent < ViewComponent::Base
 
 
-  def initialize(id:, name: , label: '', value: '', checked: false, boolean_switch: false, style: nil, help: nil)
+  def initialize(id:, name: , label: '', value: '', checked: false, boolean_switch: false, style: nil, help: nil, data: {})
     super
     @id = id
     @name = name
@@ -13,6 +13,7 @@ class SwitchInputComponent < ViewComponent::Base
     @boolean_switch = boolean_switch
     @style = style
     @help = help
+    @data = data
   end
 
   def boolean_switch_action

--- a/app/components/switch_input_component/switch_input_component.html.haml
+++ b/app/components/switch_input_component/switch_input_component.html.haml
@@ -1,4 +1,4 @@
-%div.switch-filter
+%div.switch-filter{data: @data}
   - if content || !@label.empty?
     = content_tag(:div, content || @label, style: @style)
   - if @boolean_switch

--- a/app/helpers/inputs_helper.rb
+++ b/app/helpers/inputs_helper.rb
@@ -36,8 +36,8 @@ module InputsHelper
     end
   end
 
-  def switch_input(id:, name:, label:, checked: false, value: '', boolean_switch: false, style: nil, help: nil)
-    render SwitchInputComponent.new(id: id, name: name, label: label, checked: checked, value: value, boolean_switch: boolean_switch, style: style, help: help)
+  def switch_input(id:, name:, label:, checked: false, value: '', boolean_switch: false, style: nil, help: nil, data: {})
+    render SwitchInputComponent.new(id: id, name: name, label: label, checked: checked, value: value, boolean_switch: boolean_switch, style: style, help: help, data: data)
   end
 
   def url_input(name:, value:, label: nil, help: nil)

--- a/app/javascript/controllers/auto_mapping_filter_controller.js
+++ b/app/javascript/controllers/auto_mapping_filter_controller.js
@@ -6,7 +6,7 @@ export default class extends Controller {
   toggle(event) {
     const status_hide = event.target.checked 
 
-    const autoSources = ['LOOM']
+    const autoSources = ['LOOM','CUI', 'SAME_URI']
 
     this.element.querySelectorAll('tr').forEach((row) => {
       const isAutomatic = autoSources.some((type) =>

--- a/app/javascript/controllers/auto_mapping_filter_controller.js
+++ b/app/javascript/controllers/auto_mapping_filter_controller.js
@@ -1,0 +1,19 @@
+import { Controller } from "@hotwired/stimulus"
+// Connects to data-controller="auto-mapping-filter"
+
+export default class extends Controller {
+
+  toggle(event) {
+    const status_hide = event.target.checked 
+
+    const autoSources = ['LOOM']
+
+    this.element.querySelectorAll('tr').forEach((row) => {
+      const isAutomatic = autoSources.some((type) =>
+        row.classList.contains(type)
+      )
+
+      row.style.display = status_hide && isAutomatic ? 'none' : ''
+    })
+  }
+}

--- a/app/javascript/controllers/auto_mapping_filter_controller.js
+++ b/app/javascript/controllers/auto_mapping_filter_controller.js
@@ -6,7 +6,7 @@ export default class extends Controller {
 
   toggle(event) {
     const hide = event.target.checked 
-    const autoSources = ['LOOM','CUI', 'SAME_URI']
+    const autoSources = ['LOOM','CUI']
     let count = 0
 
     this.rowTargets.forEach((row) => {

--- a/app/javascript/controllers/auto_mapping_filter_controller.js
+++ b/app/javascript/controllers/auto_mapping_filter_controller.js
@@ -2,18 +2,17 @@ import { Controller } from "@hotwired/stimulus"
 // Connects to data-controller="auto-mapping-filter"
 
 export default class extends Controller {
+  static targets = ["row"]
 
   toggle(event) {
-    const status_hide = event.target.checked 
+    const hide = event.target.checked 
 
     const autoSources = ['LOOM','CUI', 'SAME_URI']
 
-    this.element.querySelectorAll('tr').forEach((row) => {
-      const isAutomatic = autoSources.some((type) =>
-        row.classList.contains(type)
-      )
+    this.rowTargets.forEach((row) => {
+      const isAutomatic = autoSources.includes(row.dataset.source)   
 
-      row.style.display = status_hide && isAutomatic ? 'none' : ''
+      row.style.display = hide && isAutomatic ? 'none' : ''
     })
   }
 }

--- a/app/javascript/controllers/auto_mapping_filter_controller.js
+++ b/app/javascript/controllers/auto_mapping_filter_controller.js
@@ -17,7 +17,10 @@ export default class extends Controller {
     })
 
     if(this.hasEmptyMessageTarget) {
-      this.emptyMessageTarget.style.display = count === this.rowTargets.length ? '' : 'none'
+      const hasRows = this.rowTargets.length > 0
+      const allHidden = count === this.rowTargets.length //number of hidden rows == to the total number of rows??
+
+      this.emptyMessageTarget.style.display = hasRows && allHidden ? '' : 'none'
     }
   }
 }

--- a/app/javascript/controllers/auto_mapping_filter_controller.js
+++ b/app/javascript/controllers/auto_mapping_filter_controller.js
@@ -2,17 +2,22 @@ import { Controller } from "@hotwired/stimulus"
 // Connects to data-controller="auto-mapping-filter"
 
 export default class extends Controller {
-  static targets = ["row"]
+  static targets = ["row", "emptyMessage"]
 
   toggle(event) {
     const hide = event.target.checked 
-
     const autoSources = ['LOOM','CUI', 'SAME_URI']
+    let count = 0
 
     this.rowTargets.forEach((row) => {
       const isAutomatic = autoSources.includes(row.dataset.source)   
-
       row.style.display = hide && isAutomatic ? 'none' : ''
+
+      if(row.style.display === 'none') count++
     })
+
+    if(this.hasEmptyMessageTarget) {
+      this.emptyMessageTarget.style.display = count === this.rowTargets.length ? '' : 'none'
+    }
   }
 }

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -105,3 +105,6 @@ application.register('concepts-json', ConceptsJsonButtonController)
 
 import ParentCategoriesSelectorController from "./parent_categories_selector_controller.js"
 application.register('parent-categories-selector', ParentCategoriesSelectorController)
+
+import AutoMappingFilterController from "./auto_mapping_filter_controller"
+application.register('auto-mapping-filter', AutoMappingFilterController)

--- a/app/views/mappings/_concept_mappings.html.haml
+++ b/app/views/mappings/_concept_mappings.html.haml
@@ -2,16 +2,18 @@
   = "#{@mappings.size}"
 
 = turbo_frame_tag @type.eql?('modal') ? 'application_modal_content' : 'concept_mappings' do
-  %div.p-1
-    - if session[:user].nil?
-      = link_to "Create New Mapping", "/login?redirect=/ontologies/#{@ontology.acronym}/?p=classes&t=mappings&conceptid=#{escape(@concept.id)}", :method => :get, :class => "btn btn-default mb-3"
-    - else
-      %div{style: 'width: 250px; margin: 0 0 10px 0;'}
-        = link_to_modal(nil,
-                  new_mapping_path(ontology_from: "#{@ontology.id}", conceptid_from: "#{@concept.id}"),
-                  data: { show_modal_title_value: "Create a new mapping for #{@concept.prefLabel}" },
-                  ) do
-          = render Buttons::RegularButtonComponent.new(id:'new_mapping_btn' , value:t('mappings.create_new_mapping'), variant: 'secondary', size: 'slim', state: 'no-anim')
-
+  %div.p-1{data: {controller: 'auto-mapping-filter'}}
+    %div.d-flex.justify-content-between.align-items-center.mb-3
+      - if session[:user].nil?
+        = link_to "Create New Mapping", "/login?redirect=/ontologies/#{@ontology.acronym}/?p=classes&t=mappings&conceptid=#{escape(@concept.id)}", :method => :get, :class => "btn btn-default"
+      - else
+        %div{style: 'width: 250px;'}
+          = link_to_modal(nil,
+                    new_mapping_path(ontology_from: "#{@ontology.id}", conceptid_from: "#{@concept.id}"),
+                    data: { show_modal_title_value: "Create a new mapping for #{@concept.prefLabel}" },
+                    ) do
+            = render Buttons::RegularButtonComponent.new(id:'new_mapping_btn' , value:t('mappings.create_new_mapping'), variant: 'secondary', size: 'slim', state: 'no-anim')
+      = switch_input(id: 'hide_automatic_mappings', name: 'hide_automatic_mappings', label: t('mappings.mapping_table.hide_automatic_mappings'), data: {action: 'change->auto-mapping-filter#toggle'})
     #mapping_details
       = render :partial => '/mappings/mapping_table'
+

--- a/app/views/mappings/_concept_mappings.html.haml
+++ b/app/views/mappings/_concept_mappings.html.haml
@@ -13,7 +13,7 @@
                     data: { show_modal_title_value: "Create a new mapping for #{@concept.prefLabel}" },
                     ) do
             = render Buttons::RegularButtonComponent.new(id:'new_mapping_btn' , value:t('mappings.create_new_mapping'), variant: 'secondary', size: 'slim', state: 'no-anim')
-      = switch_input(id: 'hide_automatic_mappings', name: 'hide_automatic_mappings', label: t('mappings.mapping_table.hide_automatic_mappings'), data: {action: 'change->auto-mapping-filter#toggle'})
+      = switch_input(id: 'hide_automatic_mappings', name: 'hide_automatic_mappings', label: t('mappings.mapping_table.hide_automatic_mappings'), data: {auto_mapping_filter_target: 'toggle' , action: 'change->auto-mapping-filter#toggle'})
     #mapping_details
       = render :partial => '/mappings/mapping_table'
 

--- a/app/views/mappings/_concept_mappings.html.haml
+++ b/app/views/mappings/_concept_mappings.html.haml
@@ -13,7 +13,7 @@
                     data: { show_modal_title_value: "Create a new mapping for #{@concept.prefLabel}" },
                     ) do
             = render Buttons::RegularButtonComponent.new(id:'new_mapping_btn' , value:t('mappings.create_new_mapping'), variant: 'secondary', size: 'slim', state: 'no-anim')
-      = switch_input(id: 'hide_automatic_mappings', name: 'hide_automatic_mappings', label: t('mappings.mapping_table.hide_automatic_mappings'), data: {auto_mapping_filter_target: 'toggle' , action: 'change->auto-mapping-filter#toggle'})
+      = switch_input(id: 'hide_generated_mappings', name: 'hide_generated_mappings', label: t('mappings.mapping_table.hide_generated_mappings'), data: {auto_mapping_filter_target: 'toggle' , action: 'change->auto-mapping-filter#toggle'})
     #mapping_details
       = render :partial => '/mappings/mapping_table'
 

--- a/app/views/mappings/_mapping_table.html.haml
+++ b/app/views/mappings/_mapping_table.html.haml
@@ -1,7 +1,6 @@
 = check_box_tag "delete_mappings_permission", @delete_mapping_permission, @delete_mapping_permission, style: "display: none;"
-%div#concept_mappings_tables_div{data: {controller: 'auto-mapping-filter'}}
+%div#concept_mappings_tables_div
   = render_alerts_container(MappingsController)
-  = switch_input(id: 'hide_automatic_mappings', name: 'hide_automatic_mappings', label: t('mappings.mapping_table.hide_automatic_mappings'), data: {action: 'change->auto-mapping-filter#toggle'})
   %table#concept_mappings_table.table-content-stripped.table-content.table-mini
     %thead
       %tr

--- a/app/views/mappings/_mapping_table.html.haml
+++ b/app/views/mappings/_mapping_table.html.haml
@@ -1,6 +1,7 @@
 = check_box_tag "delete_mappings_permission", @delete_mapping_permission, @delete_mapping_permission, style: "display: none;"
-%div#concept_mappings_tables_div
+%div#concept_mappings_tables_div{data: {controller: 'auto-mapping-filter'}}
   = render_alerts_container(MappingsController)
+  = switch_input(id: 'hide_automatic_mappings', name: 'hide_automatic_mappings', label: t('mappings.mapping_table.hide_automatic_mappings'), data: {action: 'change->auto-mapping-filter#toggle'})
   %table#concept_mappings_table.table-content-stripped.table-content.table-mini
     %thead
       %tr

--- a/app/views/mappings/_mapping_table.html.haml
+++ b/app/views/mappings/_mapping_table.html.haml
@@ -14,3 +14,5 @@
         = render partial: 'mappings/show_line' , locals: {map: map, concept: @concept}
       %tr.empty-state
         %td.text-center{:colspan => "6"}= t("mappings.mapping_table.no_mappings")
+      %tr{'data-auto-mapping-filter-target' => 'emptyMessage', style: 'display: none'}
+        %td.text-center{:colspan => "6"}= t("mappings.mapping_table.no_manual_mappings")

--- a/app/views/mappings/_mapping_table.html.haml
+++ b/app/views/mappings/_mapping_table.html.haml
@@ -14,5 +14,5 @@
         = render partial: 'mappings/show_line' , locals: {map: map, concept: @concept}
       %tr.empty-state
         %td.text-center{:colspan => "6"}= t("mappings.mapping_table.no_mappings")
-      %tr{'data-auto-mapping-filter-target' => 'emptyMessage', style: 'display: none'}
+      %tr{'data-auto-mapping-filter-target': 'emptyMessage', style: 'display: none'}
         %td.text-center{:colspan => "6"}= t("mappings.mapping_table.no_manual_mappings")

--- a/app/views/mappings/_show.html.haml
+++ b/app/views/mappings/_show.html.haml
@@ -1,8 +1,9 @@
 = render_in_modal do
   #mappings.paginate_ajax{:style => "overflow: auto; max-height: 600px;"}
-    #mapping_results
+    #mapping_results{data: {controller: 'auto-mapping-filter'}}
       .mappings-table-pagination
         = will_paginate @page_results, :update => 'mappings', :params => { :target => params[:target] }
+        = switch_input(id: 'hide_automatic_mappings', name: 'hide_automatic_mappings', label: t('mappings.mapping_table.hide_automatic_mappings'), data: {action: 'change->auto-mapping-filter#toggle'})
       - if @mappings.nil? or @mappings.empty?
         = t("mappings.show.no_mappings_found")
       - else            
@@ -12,7 +13,7 @@
             %th #{@target_ontology_name}
             %th Source
           - for map in @mappings
-            %tr
+            %tr{class: map.source}
               - map.classes.each do |cls|
                 %td
                   - if internal_mapping?(cls)

--- a/app/views/mappings/_show.html.haml
+++ b/app/views/mappings/_show.html.haml
@@ -1,7 +1,7 @@
 = render_in_modal do
   #mappings.paginate_ajax{:style => "overflow: auto; max-height: 600px;"}
     #mapping_results{data: {controller: 'auto-mapping-filter'}}
-      .mappings-table-pagination
+      .mappings-table-pagination.d-flex.justify-content-between.align-items-center.pr-3
         = will_paginate @page_results, :update => 'mappings', :params => { :target => params[:target] }
         = switch_input(id: 'hide_automatic_mappings', name: 'hide_automatic_mappings', label: t('mappings.mapping_table.hide_automatic_mappings'), data: {action: 'change->auto-mapping-filter#toggle'})
       - if @mappings.nil? or @mappings.empty?

--- a/app/views/mappings/_show.html.haml
+++ b/app/views/mappings/_show.html.haml
@@ -3,7 +3,7 @@
     #mapping_results{data: {controller: 'auto-mapping-filter'}}
       .mappings-table-pagination.d-flex.justify-content-between.align-items-center.pr-3
         = will_paginate @page_results, :update => 'mappings', :params => { :target => params[:target] }
-        = switch_input(id: 'hide_automatic_mappings', name: 'hide_automatic_mappings', label: t('mappings.mapping_table.hide_automatic_mappings'), data: {action: 'change->auto-mapping-filter#toggle'})
+        = switch_input(id: 'hide_automatic_mappings_modal', name: 'hide_automatic_mappings_modal', label: t('mappings.mapping_table.hide_automatic_mappings'), data: {auto_mapping_filter_target: 'toggle', action: 'change->auto-mapping-filter#toggle'})
       - if @mappings.nil? or @mappings.empty?
         = t("mappings.show.no_mappings_found")
       - else            
@@ -13,7 +13,7 @@
             %th #{@target_ontology_name}
             %th Source
           - for map in @mappings
-            %tr{class: map.source}
+            %tr{'data-source' => map.source, 'data-auto-mapping-filter-target' => 'row'}
               - map.classes.each do |cls|
                 %td
                   - if internal_mapping?(cls)

--- a/app/views/mappings/_show.html.haml
+++ b/app/views/mappings/_show.html.haml
@@ -13,7 +13,7 @@
             %th #{@target_ontology_name}
             %th Source
           - for map in @mappings
-            %tr{'data-source' => map.source, 'data-auto-mapping-filter-target' => 'row'}
+            %tr{'data-source' => map.source, 'data-auto-mapping-filter-target': 'row'}
               - map.classes.each do |cls|
                 %td
                   - if internal_mapping?(cls)
@@ -22,7 +22,7 @@
                     = ajax_to_external_cls(cls)
               %td
                 #{map.source} #{(map.process || {})[:source_name]}
-          %tr{'data-auto-mapping-filter-target' => 'emptyMessage', style: 'display: none'}
+          %tr{'data-auto-mapping-filter-target': 'emptyMessage', style: 'display: none'}
             %td.text-center{:colspan => "3"}= t("mappings.mapping_table.no_manual_mappings")
       .mappings-table-pagination
         = will_paginate @page_results, :update => 'mappings', :params => { :target => params[:target] }

--- a/app/views/mappings/_show.html.haml
+++ b/app/views/mappings/_show.html.haml
@@ -3,7 +3,7 @@
     #mapping_results{data: {controller: 'auto-mapping-filter'}}
       .mappings-table-pagination.d-flex.justify-content-between.align-items-center.pr-3
         = will_paginate @page_results, :update => 'mappings', :params => { :target => params[:target] }
-        = switch_input(id: 'hide_automatic_mappings_modal', name: 'hide_automatic_mappings_modal', label: t('mappings.mapping_table.hide_automatic_mappings'), data: {auto_mapping_filter_target: 'toggle', action: 'change->auto-mapping-filter#toggle'})
+        = switch_input(id: 'hide_generated_mappings_modal', name: 'hide_generated_mappings_modal', label: t('mappings.mapping_table.hide_generated_mappings'), data: {auto_mapping_filter_target: 'toggle', action: 'change->auto-mapping-filter#toggle'})
       - if @mappings.nil? or @mappings.empty?
         = t("mappings.show.no_mappings_found")
       - else            

--- a/app/views/mappings/_show.html.haml
+++ b/app/views/mappings/_show.html.haml
@@ -22,5 +22,7 @@
                     = ajax_to_external_cls(cls)
               %td
                 #{map.source} #{(map.process || {})[:source_name]}
+          %tr{'data-auto-mapping-filter-target' => 'emptyMessage', style: 'display: none'}
+            %td.text-center{:colspan => "3"}= t("mappings.mapping_table.no_manual_mappings")
       .mappings-table-pagination
         = will_paginate @page_results, :update => 'mappings', :params => { :target => params[:target] }

--- a/app/views/mappings/_show_line.html.haml
+++ b/app/views/mappings/_show_line.html.haml
@@ -2,7 +2,7 @@
 - cls_link, ont_link, source_tooltip = mapping_links(map, concept)
 - map_id = map.id.to_s.split("/").last
 
-%tr.human{:id => map_id}
+%tr.human{:id => map_id, class: map.source}
   %td.mappings-table-mapping-to
     = cls_link
   %td.mappings-table-mapping-to

--- a/app/views/mappings/_show_line.html.haml
+++ b/app/views/mappings/_show_line.html.haml
@@ -2,7 +2,7 @@
 - cls_link, ont_link, source_tooltip = mapping_links(map, concept)
 - map_id = map.id.to_s.split("/").last
 
-%tr.human{:id => map_id, 'data-source' => map.source, 'data-auto-mapping-filter-target' => 'row'}
+%tr.human{:id => map_id, 'data-source' => map.source, 'data-auto-mapping-filter-target': 'row'}
   %td.mappings-table-mapping-to
     = cls_link
   %td.mappings-table-mapping-to

--- a/app/views/mappings/_show_line.html.haml
+++ b/app/views/mappings/_show_line.html.haml
@@ -2,7 +2,7 @@
 - cls_link, ont_link, source_tooltip = mapping_links(map, concept)
 - map_id = map.id.to_s.split("/").last
 
-%tr.human{:id => map_id, class: map.source}
+%tr.human{:id => map_id, 'data-source' => map.source, 'data-auto-mapping-filter-target' => 'row'}
   %td.mappings-table-mapping-to
     = cls_link
   %td.mappings-table-mapping-to

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -859,7 +859,7 @@ en:
       relations: Relations
       source: Source
       type: Type
-      hide_automatic_mappings: Hide automatic mappings
+      hide_generated_mappings: Hide generated mappings
       no_manual_mappings: No manual mappings found
     mapping_type_selector:
       class: Class

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -860,6 +860,7 @@ en:
       source: Source
       type: Type
       hide_automatic_mappings: Hide automatic mappings
+      no_manual_mappings: No manual mappings found
     mapping_type_selector:
       class: Class
       class_uri_placeholder: Enter the class URI

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -859,6 +859,7 @@ en:
       relations: Relations
       source: Source
       type: Type
+      hide_automatic_mappings: Hide automatic mappings
     mapping_type_selector:
       class: Class
       class_uri_placeholder: Enter the class URI

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -888,6 +888,7 @@ fr:
       relations: Relations
       source: Source
       type: Type
+      hide_automatic_mappings: Masquer les mappings automatiques
     mapping_type_selector:
       class: Classe
       class_uri_placeholder: Entrez l'URI de la classe

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -888,7 +888,7 @@ fr:
       relations: Relations
       source: Source
       type: Type
-      hide_automatic_mappings: Masquer les mappings automatiques
+      hide_generated_mappings: Masquer les mappings générés
       no_manual_mappings: Aucun mapping manuel trouvé
     mapping_type_selector:
       class: Classe

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -889,6 +889,7 @@ fr:
       source: Source
       type: Type
       hide_automatic_mappings: Masquer les mappings automatiques
+      no_manual_mappings: Aucun mapping manuel trouvé
     mapping_type_selector:
       class: Classe
       class_uri_placeholder: Entrez l'URI de la classe


### PR DESCRIPTION
Add a toggle to hide/show automatic mappings (LOOM, CUI,) in the mapping results table

Changes implemented:
  -  Added a UI toggle to control the visibility of automatic mappings
  -  Implemented frontend filtering logic to hide/show rows dynamically

<img width="805" height="303" alt="image" src="https://github.com/user-attachments/assets/c71275ef-8162-44c7-92de-80ef306e4b2b" />

A video demonstration is provided to show how the toggle works :
[Capture vidéo du 2026-03-19 14-06-08.webm](https://github.com/user-attachments/assets/3ae35131-7c10-4996-8f2b-f85906d292f1)




