### PR TITLE
Fix home metrics showing global stats on slice

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -6,7 +6,7 @@ class HomeController < ApplicationController
   include FairScoreHelper, FederationHelper,MetricsHelper
 
   def index
-    @analytics = Rails.cache.fetch("ontologies_analytics-#{Time.now.year}-#{Time.now.month}", expires_in: 2.hours) do
+    @analytics = Rails.cache.fetch("ontologies_analytics-#{@subdomain_filter[:acronym].presence || 'all'}-#{Time.now.year}-#{Time.now.month}", expires_in: 2.hours) do
       helpers.ontologies_analytics
     end
 
@@ -24,7 +24,7 @@ class HomeController < ApplicationController
 
   # Add a new action for the metrics frame
   def metrics
-    @analytics = Rails.cache.fetch("ontologies_analytics-#{Time.now.year}-#{Time.now.month}", expires_in: 2.hours) do
+    @analytics = Rails.cache.fetch("ontologies_analytics-#{@subdomain_filter[:acronym].presence || 'all'}-#{Time.now.year}-#{Time.now.month}", expires_in: 2.hours) do
       helpers.ontologies_analytics
     end
     @metrics = portal_metrics(@analytics)


### PR DESCRIPTION
On slice subdomains (e.g. dataterra.earthportal.eu), the "in figures"
block showed the whole portal's stats instead of the slice's.

Cause: the analytics used to compute the metrics were cached under a
global key (`ontologies_analytics-YYYY-MM`), shared between the main
portal and every slice.

Fix: include the slice acronym in the cache key, so each slice (and the
main portal) gets its own slice-filtered analytics.
